### PR TITLE
ACAN_ESP32: Add ACAN_ESP32::end() to stop the controller and remove ISR

### DIFF
--- a/src/ACAN_ESP32.cpp
+++ b/src/ACAN_ESP32.cpp
@@ -213,6 +213,25 @@ uint32_t ACAN_ESP32::begin (const ACAN_ESP32_Settings & inSettings,
 }
 
 //----------------------------------------------------------------------------------------
+//   Stop CAN controller and uninstall ISR
+//----------------------------------------------------------------------------------------
+
+void ACAN_ESP32::end (void) {
+//--------------------------------- Abort any pending transfer, don't care about resetting
+  TWAI_CMD_REG = TWAI_ABORT_TX ;
+
+//--------------------------------- Disable Interupts
+  TWAI_INT_ENA_REG = 0 ;
+  if (mInterruptHandler != nullptr) {
+    esp_intr_free (mInterruptHandler) ;
+    mInterruptHandler = nullptr ;
+  }
+
+//--------------------------------- Disable CAN module
+  periph_module_disable (PERIPH_TWAI_MODULE) ;
+}
+
+//----------------------------------------------------------------------------------------
 //--- Status Flags (returns 0 if no error)
 //  Bit 0 : hardware receive FIFO overflow
 //  Bit 1 : driver receive FIFO overflow

--- a/src/ACAN_ESP32.h
+++ b/src/ACAN_ESP32.h
@@ -31,6 +31,11 @@ class ACAN_ESP32 {
                           const ACAN_ESP32_Filter & inFilterSettings = ACAN_ESP32_Filter::acceptAll ()) ;
 
   // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+  //    Deinit: Stop CAN controller and uninstall ISR 
+  // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+  public: void end (void) ;
+
+  // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
   //    CAN  Configuration Private Methods
   // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 


### PR DESCRIPTION
Some applications require stopping the controller (at least temporarily) for example when starting the OTA process as, during that, getting any interrupt from the CAN controller may be not desirable, as that could be increasing the likeliness of an OTA failure (and noone wants to end up with a corrupt flash).

The OTA case is just one of the possible examples, anyway.

This was tested on ESP32-S3R8 and S3R2.